### PR TITLE
Add esm1.6 and requirements.txt

### DIFF
--- a/configs/esm1.6.yaml
+++ b/configs/esm1.6.yaml
@@ -33,8 +33,8 @@ Perturbation_Experiment:
       - 4nodes
       - 8nodes
     atmosphere/um_env.yaml:
-      UM_ATM_NPROCX: ["4", "8", "16", "16"]
-      UM_ATM_NPROCY: ["13", "13", "13", "26"]
+      UM_ATM_NPROCX: ["4", "8", "16", "26"]
+      UM_ATM_NPROCY: ["13", "13", "13", "16"]
       UM_NPES: ["52", "104", "208", "416"]
     ice/cice_in.nml:
       domain_nml:

--- a/configs/esm1.6.yaml
+++ b/configs/esm1.6.yaml
@@ -1,0 +1,133 @@
+# Experiment Configuration File
+
+
+model_type: access-esm1.6
+repository_url: git@github.com:ACCESS-NRI/access-esm1.6-configs.git
+start_point: "61b5e1c"
+test_path: esm1.6-scaling
+repository_directory: PI_concentrations
+
+control_branch_name: ctrl
+
+Control_Experiment:
+  config.yaml:
+    modules:
+      use:
+        - /g/data/vk83/modules
+        # tmp location for cice5 binaries
+        - /g/data/tm70/ey7514/spack/0.22/release/modules/linux-rocky8-x86_64_v4
+      load:
+        # tmp local module
+        - cice5/access-esm1.6-bkvt77m
+        - access-esm1p6/2025.07.001
+    # tmp workaround while local cice5 binaries are being used
+    manifest:
+      reproduce:
+        exe: false
+
+Perturbation_Experiment:
+  Parameter_block1:
+    branches:
+      - 1nodes
+      - 2nodes
+      - 4nodes
+      - 8nodes
+    atmosphere/um_env.yaml:
+      UM_ATM_NPROCX: ["4", "8", "16", "16"]
+      UM_ATM_NPROCY: ["13", "13", "13", "26"]
+      UM_NPES: ["52", "104", "208", "416"]
+    ice/cice_in.nml:
+      domain_nml:
+        nprocs: [3, 6, 12, 24]
+    ocean/input.nml:
+      ocean_model_nml:
+        layout:
+          - 7, 7
+          - 14, 7
+          - 14, 14
+          - 28, 14
+    config.yaml:
+      submodels:
+        - name: atmosphere
+          model: um
+          ncpus: [52, 104, 208, 416]
+          exe: um_hg3.exe
+          input:
+              # Aerosols
+            - - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/OCFF_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/BC_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/scycl_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/Bio_1850_cmip7.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+              # Forcing
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
+              # Land
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2024.12.18/pftlookup_cable3.csv
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+              # Spectral
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+              # Grids
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+              # STASH
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
+
+        - name: ocean
+          model: mom
+          ncpus: [49, 98, 196, 392]
+          exe: mom5_access_cm 
+          input:
+              # Biogeochemistry
+            - - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+              # Tides
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+              # Shortwave
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/shortwave_penetration/global.1deg/2025.06.23/ssw_atten_depth.nc
+              # Grids
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/grid_spec.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/ocean_mosaic.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/ocean_hgrid.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/bathymetry/global.1deg/2025.07.29/topog.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/vertical/global.1deg/2025.07.29/ocean_vgrid.nc
+
+        - name: ice
+          model: cice5
+          ncpus: [3, 6, 12, 24]
+          exe: 
+            - cice_access-esm1.6_360x300_3x1_3p.exe
+            - cice_access-esm1.6_360x300_6x1_6p.exe
+            - cice_access-esm1.6_360x300_12x1_12p.exe
+            - cice_access-esm1.6_360x300_24x1_24p.exe
+          input:
+              # Grids
+            - - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ice/grids/global.1deg/2025.07.29/kmt.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ice/grids/global.1deg/2025.07.29/grid.nc
+              # Iceberg flux
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/share/ice/iceberg/global.1deg/2024.11.08/lice_discharge_iceberg.nc
+        - name: coupler
+          model: oasis
+          ncpus: 0
+          input:
+              # Grids
+            - - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/grids/global.oi_1deg.a_N96/2025.07.29/grids.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/grids/global.oi_1deg.a_N96/2025.07.29/areas.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+              # Remapping weights
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/ACCESS-NRI/access-experiment-generator
+


### PR DESCRIPTION
This adds a first draft of the esm1.6 scaling configs to be used with access-experiment-generator. Currently, the config sets up tests for 1, 2, 4, and 8 nodes. Sub 1-node tests should be doable but haven't been done yet. 1 node setup probably needs to be optimized (since atmosphere layout is getting thin). I'll need some input on how best to optimize that.